### PR TITLE
Adapt Scala codegen to match new API for runtime library

### DIFF
--- a/StgScala/LangGeneric_scala.fs
+++ b/StgScala/LangGeneric_scala.fs
@@ -316,7 +316,7 @@ type LangGeneric_scala() =
 
         override this.bitStringValueToByteArray (v : BitStringValue) = FsUtils.bitStringValueToByteArray (StringLoc.ByValue v)
 
-        override this.generatePrecond (enc: Asn1Encoding) (t: Asn1AcnAst.Asn1Type) = [$"codec.validate_offset_bits({t.maxSizeInBits enc})"]
+        override this.generatePrecond (enc: Asn1Encoding) (t: Asn1AcnAst.Asn1Type) = [$"BitStream.validate_offset_bits(codec.base.bitStream.buf.length, codec.base.bitStream.currentByte, codec.base.bitStream.currentBit, {t.maxSizeInBits enc})"]
 
         // TODO: Non, mais avoir un AST
         override this.generatePostcond (enc: Asn1Encoding) (funcNameBase: string) (p: CallerScope) (t: Asn1AcnAst.Asn1Type) (codec: Codec) =
@@ -328,9 +328,9 @@ res match
     case Right(res) =>
         val w1 = old(codec)
         val w2 = codec
-        w1.bufLength() == w2.bufLength() && w2.bitIndex() <= w1.bitIndex() + {t.maxSizeInBits enc}"""
+        w1.base.bitStream.buf.length == w2.base.bitStream.buf.length && BitStream.bitIndex(w2.base.bitStream.buf.length, w2.base.bitStream.currentByte, w2.base.bitStream.currentBit) <= BitStream.bitIndex(w1.base.bitStream.buf.length, w1.base.bitStream.currentByte, w1.base.bitStream.currentBit) + {t.maxSizeInBits enc}"""
                 Some (res.TrimStart())
-            | Decode -> Some $"codec.base.bitStream.buf == old(codec).base.bitStream.buf && codec.base.bitStream.bitIndex() <= old(codec).base.bitStream.bitIndex() + {t.maxSizeInBits enc}"
+            | Decode -> Some $"codec.base.bitStream.buf == old(codec).base.bitStream.buf && BitStream.bitIndex(codec.base.bitStream.buf.length, codec.base.bitStream.currentByte, codec.base.bitStream.currentBit) <= BitStream.bitIndex(old(codec).base.bitStream.buf.length, old(codec).base.bitStream.currentByte, old(codec).base.bitStream.currentBit) + {t.maxSizeInBits enc}"
 
         // override this.generateSequenceChildProof (enc: Asn1Encoding) (stmts: string option list) (pg: SequenceProofGen) (codec: Codec): string list =
         //     ProofGen.generateSequenceChildProof enc stmts pg codec

--- a/StgScala/ProofGen.fs
+++ b/StgScala/ProofGen.fs
@@ -34,7 +34,7 @@ let generateReadPrefixLemmaApp (snapshots: Var list) (children: TypeInfo list) (
         | SemiConstrained max -> [IntLit max]
         | UnconstrainedMax max -> [IntLit max]
         | Unconstrained -> []
-      | _ -> [] // TODO: Rest
+    | _ -> [] // TODO: Rest
 
   let mkLemma (bs1: Var, bs2: Var, tpe: TypeInfo): Expr =
     let var = {Var.name = $"{bs2.name}_reset"; tpe = bs2.tpe}

--- a/StgScala/acn_scala.stg
+++ b/StgScala/acn_scala.stg
@@ -93,12 +93,12 @@ while <i> \< <fixedSize>.toInt do
 >>
 
 alignToNext_encode(sMainBody, sAlignmentValue, nAlignmentValue) ::= <<
-codec.alignTo<sAlignmentValue>()
+codec.base.bitStream.alignTo<sAlignmentValue>()
 <sMainBody>
 >>
 
 alignToNext_decode(sMainBody, sAlignmentValue, nAlignmentValue) ::= <<
-codec.alignTo<sAlignmentValue>()
+codec.base.bitStream.alignTo<sAlignmentValue>()
 <sMainBody>
 >>
 
@@ -291,7 +291,7 @@ Boolean_encode(p, ptr, bEncValIsTrue, nSize, arruTrueValueAsByteArray, arruFalse
 locally {
     val true_data: Array[UByte] = Array(<arruTrueValueAsByteArray:{b|0x<b;format="X2">.toUnsignedByte}; separator=", ">)
     val false_data: Array[UByte] = Array(<arruFalseValueAsByteArray:{b|0x<b;format="X2">.toUnsignedByte}; separator=", ">)
-    codec.appendBitsMSBFirst(if <p> then true_data else false_data, <nSize>)
+    codec.base.bitStream.appendBitsMSBFirst(if <p> then true_data else false_data, <nSize>)
 }
 >>
 
@@ -317,7 +317,7 @@ Null_pattern_encode(p, arruNullValueAsByteArray, nSize, arrsBits, sErrCode, bSav
 <if(arruNullValueAsByteArray)>
 locally {
     val tmp: Array[UByte] = Array(<arruNullValueAsByteArray:{b|0x<b;format="X2">.toRawUByte}; separator=",">)
-    codec.appendBitsMSBFirst(tmp, <nSize>)
+    codec.base.bitStream.appendBitsMSBFirst(tmp, <nSize>)
 }
 <endif>
 >>
@@ -438,24 +438,24 @@ val <p> = codec.dec_IA5String_CharIndex_External_Field_Determinant(<nAsn1Max>, <
 
 
 oct_external_field_encode(sTypedefName, p, sAcc, noSizeMin, nSizeMax, sExtFld, bIsUnsigned, nAlignSize, sErrCode) ::= <<
-codec.encodeOctetString_no_length(<p><sAcc>arr, <p><sAcc>nCount.toInt)
+codec.base.encodeOctetString_no_length(<p><sAcc>arr, <p><sAcc>nCount.toInt)
 >>
 
 oct_external_field_decode(sTypedefName, p, sAcc, noSizeMin, nSizeMax, sExtFld, bIsUnsigned, nAlignSize, sErrCode) ::= <<
 val <p> =
     if (<if(noSizeMin)>(<if(bIsUnsigned)>ULong.fromRaw(<noSizeMin>)<else><noSizeMin><endif> \<= <sExtFld>) && <endif>(<sExtFld> \<= <if(bIsUnsigned)>ULong.fromRaw(<nSizeMax>)<else><nSizeMax><endif>)) then
-        <sTypedefName>(<if(bIsUnsigned)><sExtFld>.toRaw.toInt<else><sExtFld><endif>, codec.decodeOctetString_no_length(<if(bIsUnsigned)><sExtFld>.toRaw.toInt<else><sExtFld><endif>))
+        <sTypedefName>(<if(bIsUnsigned)><sExtFld>.toRaw.toInt<else><sExtFld><endif>, codec.base.decodeOctetString_no_length(<if(bIsUnsigned)><sExtFld>.toRaw.toInt<else><sExtFld><endif>))
     else return LeftMut(<sErrCode>)
 >>
 
 oct_external_field_fix_size_encode(sTypedefName, p, sAcc, noSizeMin, nSizeMax, sExtFld, bIsUnsigned, nAlignSize, sErrCode) ::= <<
-codec.encodeOctetString_no_length(<p><sAcc>arr, <nSizeMax>)
+codec.base.encodeOctetString_no_length(<p><sAcc>arr, <nSizeMax>)
 >>
 
 oct_external_field_fix_size_decode(sTypedefName, p, sAcc, noSizeMin, nSizeMax, sExtFld, bIsUnsigned, nAlignSize, sErrCode) ::= <<
 val <p> =
     if (<if(noSizeMin)>(<if(bIsUnsigned)>ULong.fromRaw(<noSizeMin>)<else><noSizeMin><endif> \<= <sExtFld>) && <endif>(<sExtFld> \<= <if(bIsUnsigned)>ULong.fromRaw(<nSizeMax>)<else><nSizeMax><endif>)) then
-        <sTypedefName>(codec.decodeOctetString_no_length(<nSizeMax>))
+        <sTypedefName>(codec.base.decodeOctetString_no_length(<nSizeMax>))
     else return LeftMut(<sErrCode>)
 >>
 
@@ -488,7 +488,7 @@ val <p> =
 
 oct_sqf_null_terminated_encode(p, sAcc, i, sInternalItem, noSizeMin, nSizeMax, arruNullBytes, nBitPatternLength, sErrCode, nIntItemMinSize, nIntItemMaxSize) ::= <<
 <loopFixedItem(i=i, sInternalItem=sInternalItem, fixedSize=[p, sAcc, "nCount"])>
-codec.appendBitsMSBFirst(Array({<arruNullBytes; separator=", ">}), <nBitPatternLength>)
+codec.base.bitStream.appendBitsMSBFirst(Array({<arruNullBytes; separator=", ">}), <nBitPatternLength>)
 >>
 
 oct_sqf_null_terminated_decode(p, sAcc, i, sInternalItem, noSizeMin, nSizeMax, arruNullBytes, nBitPatternLength, sErrCode, nIntItemMinSize, nIntItemMaxSize) ::= <<
@@ -511,34 +511,34 @@ else if checkBitPatternPresentResult.get then
 >>
 
 bit_string_external_field_encode(sTypeDefName, p, sErrCode, sAcc, noSizeMin, nSizeMax, sExtFld) ::= <<
-codec.appendBitsMSBFirst(<p><sAcc>arr, <p><sAcc>nCount)
+codec.base.bitStream.appendBitsMSBFirst(<p><sAcc>arr, <p><sAcc>nCount)
 >>
 
 bit_string_external_field_decode(sTypeDefName, p, sErrCode, sAcc, noSizeMin, nSizeMax, sExtFld) ::= <<
 val <p> =
     if <if(noSizeMin)>(<noSizeMin>\<=<sExtFld>) && <endif>(<sExtFld>\<=<nSizeMax>) then
-        <sTypedefName>(<sExtFld>, codec.readBits(<sExtFld>))
+        <sTypedefName>(<sExtFld>, codec.base.bitStream.readBits(<sExtFld>))
     else return LeftMut(<sErrCode>)
 >>
 
 bit_string_external_field_fixed_size_encode(sTypeDefName, p, sErrCode, sAcc, noSizeMin, nSizeMax, sExtFld) ::= <<
-codec.appendBitsMSBFirst(<p><sAcc>arr, <nSizeMax>)
+codec.base.bitStream.appendBitsMSBFirst(<p><sAcc>arr, <nSizeMax>)
 >>
 
 bit_string_external_field_fixed_size_decode(sTypeDefName, p, sErrCode, sAcc, noSizeMin, nSizeMax, sExtFld) ::= <<
 val <p> =
     if <if(noSizeMin)>(<noSizeMin>\<=<sExtFld>) && <endif>(<sExtFld>\<=<nSizeMax>) then
-        <sTypeDefName>(codec.readBits(<nSizeMax>))
+        <sTypeDefName>(codec.base.bitStream.readBits(<nSizeMax>))
     else return LeftMut(<sErrCode>)
 >>
 
 bit_string_null_terminated_encode(sTypeDefName, p, sErrCode, sAcc, i, noSizeMin, nSizeMax, arruNullBytes, nBitPatternLength) ::= <<
-codec.appendBitsMSBFirst(<p><sAcc>arr, <p><sAcc>arr.length*8) // TODO: re-introduce nCount?  -> codec.appendBitsMSBFirst(<p><sAcc>arr, <p><sAcc>nCount)
-codec.appendBitsMSBFirst(Array({<arruNullBytes; separator=", ">}), <nBitPatternLength>)
+codec.base.bitStream.appendBitsMSBFirst(<p><sAcc>arr, <p><sAcc>arr.length*8) // TODO: re-introduce nCount?  -> codec.base.bitStream.appendBitsMSBFirst(<p><sAcc>arr, <p><sAcc>nCount)
+codec.base.bitStream.appendBitsMSBFirst(Array({<arruNullBytes; separator=", ">}), <nBitPatternLength>)
 >>
 
 bit_string_null_terminated_decode(sTypeDefName, p, sErrCode, sAcc, i, noSizeMin, nSizeMax, arruNullBytes, nBitPatternLength) ::= <<
-val <p> = codec.readBits_nullterminated(Array({<arruNullBytes; separator=", ">}), <nBitPatternLength>, <nSizeMax>) match
+val <p> = codec.base.bitStream.readBits_nullterminated(Array({<arruNullBytes; separator=", ">}), <nBitPatternLength>, <nSizeMax>) match
     case NoneMut() => return LeftMut(<sErrCode>)
     case SomeMut(arr, i) => <sTypeDefName>(arr)
 >>
@@ -564,11 +564,11 @@ ReferenceType1_decode(p, sName, bAcnEncodeFuncRequiresResult, arrsArgs, arrsLoca
 
 
 sequence_presence_optChild_encode(p, sAcc, sChName, soExistVar, sErrCode) ::= <<
-codec.appendBit(<p><sAcc><sChName>.isDefined)
+codec.base.bitStream.appendBit(<p><sAcc><sChName>.isDefined)
 >>
 
 sequence_presence_optChild_decode(p, sAcc, sChName, soExistVar, sErrCode) ::= <<
-<soExistVar> = codec.readBit()
+<soExistVar> = codec.base.bitStream.readBit()
 >>
 
 sequence_presence_optChild_pres_acn_expression_encode(p, sAcc, sChName, sAcnExpression, soExistVar, sErrCode) ::= <<
@@ -720,7 +720,7 @@ case <nChildIndex> =>
 
 ChoiceChild_encode(p, sAcc, sChildID, nChildIndex, nIndexSizeInBits, nLastItemIndex, sChildContent, sChildName, sChildTypeDef, sChoiceTypeName, sChildInitExpr) ::= <<
 case <sChildID>(<sChildName>) =>
-    codec.encodeConstrainedWholeNumber(<nChildIndex>, 0, <nLastItemIndex>)
+    codec.base.encodeConstrainedWholeNumber(<nChildIndex>, 0, <nLastItemIndex>)
     <sChildContent>
 >>
 
@@ -736,7 +736,7 @@ Choice_encode(p, sAcc, arrsChildren, nLastItemIndex, sChoiceIndexName, td/*:FE_C
 >>
 
 Choice_decode(p, sAcc, arrsChildren, nLastItemIndex, sChoiceIndexName, td/*:FE_ChoiceTypeDefinition*/, nIndexSizeInBits, sErrCode) ::= <<
-val <p> = codec.decodeConstrainedWholeNumber(0, <nLastItemIndex>) match
+val <p> = codec.base.decodeConstrainedWholeNumber(0, <nLastItemIndex>) match
     <arrsChildren: {ch|<ch>}; separator="\n">
     case _ => return LeftMut(<sErrCode>)
 >>
@@ -915,7 +915,7 @@ SizeDependency_oct_str_containing(p, sFuncName, sReqBytesForUperEncoding, v, bIs
 >>
 
 octet_string_containing_ext_field_func_encode(p, sFuncName, sReqBytesForUperEncoding, sExtField, sErrCode, soInner) ::= <<
-codec.encodeOctetString_no_length(arr, <sExtField>.toInt)
+codec.base.encodeOctetString_no_length(arr, <sExtField>.toInt)
 >>
 
 octet_string_containing_ext_field_func_decode(p, sFuncName, sReqBytesForUperEncoding, sExtField, sErrCode, soInner) ::= <<
@@ -926,7 +926,7 @@ octet_string_containing_ext_field_func_decode(p, sFuncName, sReqBytesForUperEnco
     val bitStrm: BitStream = BitStream_Init(<sReqBytesForUperEncoding>)
 
     if <sExtField>.toInt \<= <sReqBytesForUperEncoding> then
-        codec.decodeOctetString_no_length(<sExtField>.toInt) match
+        codec.base.decodeOctetString_no_length(<sExtField>.toInt) match
             case NoneMut() =>
                 return LeftMut(<pErrCode>)
             case SomeMut(arr) =>
@@ -939,7 +939,7 @@ octet_string_containing_ext_field_func_decode(p, sFuncName, sReqBytesForUperEnco
 >>
 
 bit_string_containing_ext_field_func_encode(p, sFuncName, sReqBytesForUperEncoding, sReqBitsForUperEncoding, sExtField, sErrCode) ::= <<
-codec.appendBitsMSBFirst(arr, <sExtField>.toInt)
+codec.base.bitStream.appendBitsMSBFirst(arr, <sExtField>.toInt)
 >>
 
 bit_string_containing_ext_field_func_decode(p, sFuncName, sReqBytesForUperEncoding, sReqBitsForUperEncoding, sExtField, sErrCode) ::= <<
@@ -948,7 +948,7 @@ bit_string_containing_ext_field_func_decode(p, sFuncName, sReqBytesForUperEncodi
     /* decode to a temporary bitstream */
     val bitStrm: BitStream = BitStream_Init(<sReqBytesForUperEncoding>)
     if <sExtField>.toInt \<= <sReqBitsForUperEncoding> then
-        codec.readBits((int)<sExtField>) match
+        codec.base.bitStream.readBits((int)<sExtField>) match
             case NoneMut() =>
                 return LeftMut(<pErrCode>)
             case SomeMut(arr) =>
@@ -975,11 +975,11 @@ octet_string_containing_func_encode(p, sFuncName, sReqBytesForAcnEncoding, nBits
 
     int nCount = bitStrm.currentBit == 0 ? bitStrm.currentByte : (bitStrm.currentByte + 1)
     <if(bFixedSize)>
-    codec.encodeOctetString_no_length(bitStrm.buf, nCount)
+    codec.base.encodeOctetString_no_length(bitStrm.buf, nCount)
 
     <else>
-    codec.encodeConstrainedWholeNumber(nCount, <nMinSize>, <nMaxSize>)
-    codec.encodeOctetString_no_length(bitStrm.buf, nCount)
+    codec.base.encodeConstrainedWholeNumber(nCount, <nMinSize>, <nMaxSize>)
+    codec.base.encodeOctetString_no_length(bitStrm.buf, nCount)
 
     <endif>
 }
@@ -992,20 +992,20 @@ octet_string_containing_func_decode(p, sFuncName, sReqBytesForAcnEncoding, nBits
     val bitStrm: BitStream = BitStream_Init(<sReqBytesForAcnEncoding>)
 
     <if(bFixedSize)>
-    codec.decodeOctetString_no_length(<nMinSize>) match
+    codec.base.decodeOctetString_no_length(<nMinSize>) match
         case NoneMut() =>
             return LeftMut(pErrCode)
         case SomeMut(arr) =>
             bitStrm.buf = arr
     <else>
     var nCount: Int = 0
-    codec.decodeConstrainedWholeNumber(<nMinSize>, <nMaxSize>) match
+    codec.base.decodeConstrainedWholeNumber(<nMinSize>, <nMaxSize>) match
         case None() =>
             return LeftMut(pErrCode)
         case Some(x) =>
             nCount = x
 
-    codec.decodeOctetString_no_length(nCount.toInt)
+    codec.base.decodeOctetString_no_length(nCount.toInt)
         case NoneMut() =>
             return LeftMut(pErrCode)
         case SomeMut(arr) =>
@@ -1030,7 +1030,7 @@ bit_string_containing_func_encode(p, sFuncName, sReqBytesForAcnEncoding, sReqBit
 
     val nCount: Int = bitStrm.currentByte*8 + bitStrm.currentBit;
     <if(bFixedSize)>
-    codec.appendBitsMSBFirst(bitStrm.buf, nCount)
+    codec.base.bitStream.appendBitsMSBFirst(bitStrm.buf, nCount)
 
     <else>
     codec.BitStream_EncodeConstraintWholeNumber(nCount, <nMinSize>, <nMaxSize>)
@@ -1047,7 +1047,7 @@ bit_string_containing_func_decode(p, sFuncName, sReqBytesForAcnEncoding, sReqBit
     val codec: Codec = ACN(BitStream_Init(<sReqBytesForAcnEncoding>))
 
     <if(bFixedSize)>
-    codec.readBits(<nMinSize>) match
+    codec.base.bitStream.readBits(<nMinSize>) match
         case NoneMut() =>
             return LeftMut(pErrCode)
         case SomeMut(arr) =>
@@ -1059,13 +1059,13 @@ bit_string_containing_func_decode(p, sFuncName, sReqBytesForAcnEncoding, sReqBit
 
     <else>
     var nCount: Int = 0
-    codec.decodeConstrainedWholeNumber(<nMinSize>, <nMaxSize>) match
+    codec.base.decodeConstrainedWholeNumber(<nMinSize>, <nMaxSize>) match
         case None() =>
             return LeftMut(pErrCode)
         case Some(x) =>
             nCount = x
 
-    codec.readBits(nCount) match
+    codec.base.bitStream.readBits(nCount) match
         case NoneMut() =>
             return LeftMut(pErrCode)
         case SomeMut(arr) =>

--- a/StgScala/test_cases_scala.stg
+++ b/StgScala/test_cases_scala.stg
@@ -62,7 +62,7 @@ Codec_Encode(sModName, sFuncName, sVal) ::= <<
 
 Codec_Decode(sModName, sFuncName, sTasName, sEnc, sAmber) ::= <<
 // test_cases_scala.stg:62
-codec.resetBitIndex()
+codec.base.bitStream.resetBitIndex()
 // Decode value
 <sFuncName>(codec) match
     case LeftMut(_) => return Left(2)
@@ -101,9 +101,9 @@ Codec_write_bitstreamToFile() ::= <<
 // test_cases_scala.stg:99
 val file = new File(filename+".dat")
 val bw = new FileOutputStream(file)
-val l = codec.getLength
-codec.resetBitIndex()
-bw.write(codec.readByteArray(l).toArrayRaws)
+val l = codec.base.bitStream.getLength
+codec.base.bitStream.resetBitIndex()
+bw.write(codec.base.bitStream.readByteArray(l).toArrayRaws)
 bw.close()
 >>
 
@@ -389,5 +389,3 @@ import stainless.lang._
 <arrsTestFunctionBodies;separator="\n\n">
 
 >>
-
-

--- a/StgScala/uper_scala.stg
+++ b/StgScala/uper_scala.stg
@@ -82,7 +82,7 @@ def <sFuncName>_pure(codec: UPER): (UPER, EitherMut[ErrorCode, <sTypeDefName>]) 
 >>
 
 InternalItem_oct_str_encode(p, sAcc, i, sErrCode) ::=<<
-if !codec.appendByte(<p><sAcc>arr(<i>)) then
+if !codec.base.bitStream.appendByte(<p><sAcc>arr(<i>)) then
     Console.err.println("appendByte failed: not enough space for 1 byte")
 
 >>
@@ -99,52 +99,52 @@ val allowedCharSet: Array[Byte] = Array(<arrnCharSet:{ch|0x<ch;format="X2">}; wr
 InternalItem_string_with_alpha_encode(p, sErrCode, td/*:FE_StringTypeDefinition*/, i, nLastItemIndex, arrnAlphabetAsciiCodes, nAlphabetLength, nCharIndexSize) ::=<<
 <PrintAlphabet2(arrnAlphabetAsciiCodes)>
 val charIndex: Int = GetCharIndex(<p>(<i>), UByte.fromArrayRaws(allowedCharSet))
-codec.encodeConstrainedWholeNumber(charIndex, 0, <nLastItemIndex>)
+codec.base.encodeConstrainedWholeNumber(charIndex, 0, <nLastItemIndex>)
 >>
 InternalItem_string_with_alpha_decode(p, sErrCode,  td/*:FE_StringTypeDefinition*/, i, nLastItemIndex, arrnAlphabetAsciiCodes, nAlphabetLength, nCharIndexSize) ::=<<
 <PrintAlphabet2(arrnAlphabetAsciiCodes)>
 
-<p>(<i>) = allowedCharSet(codec.decodeConstrainedWholeNumber(0, <nLastItemIndex>).toInt).toRawUByte
+<p>(<i>) = allowedCharSet(codec.base.decodeConstrainedWholeNumber(0, <nLastItemIndex>).toInt).toRawUByte
 >>
 
 InternalItem_string_no_alpha_encode(p, sErrCode, i) ::=<<
-codec.encodeConstrainedWholeNumber(<p>(<i>).toRaw, 0, 127)
+codec.base.encodeConstrainedWholeNumber(<p>(<i>).toRaw, 0, 127)
 >>
 
 InternalItem_string_no_alpha_decode(p, sErrCode, i) ::=<<
-<p>(<i>) = UByte.fromRaw(codec.decodeConstrainedWholeNumberByte(0, 127)) // uper:109
+<p>(<i>) = UByte.fromRaw(codec.base.decodeConstrainedWholeNumberByte(0, 127)) // uper:109
 >>
 
 /* INTEGER START*/
 
 /*case: A:: = INTEGER (-5..20) */
 IntFullyConstraint_encode(p, nMin, nMax, nBits, sSsuffix, sErrCode) ::= <<
-codec.encodeConstrainedWholeNumber(<p>, <nMin>, <nMax>)
+codec.base.encodeConstrainedWholeNumber(<p>, <nMin>, <nMax>)
 >>
 
 IntFullyConstraint_decode(p, nMin, nMax, nBits, sSsuffix, sErrCode) ::= <<
-val <p> = codec.decodeConstrainedWholeNumber<sSsuffix>(<nMin>, <nMax>) // uper:122
+val <p> = codec.base.decodeConstrainedWholeNumber<sSsuffix>(<nMin>, <nMax>) // uper:122
 >>
 
 /*case: Positive fully constraint A:: = INTEGER (5..20) */
 IntFullyConstraintPos_encode(p, nMin, nMax, nBits, sSsuffix, sErrCode) ::= <<
-codec.encodeConstrainedPosWholeNumber(<p>, <nMin>.toRawULong, <nMax>.toRawULong)
+codec.base.encodeConstrainedPosWholeNumber(<p>, <nMin>.toRawULong, <nMax>.toRawULong)
 >>
 
 IntFullyConstraintPos_decode(p, nMin, nMax, nBits, sSsuffix, sErrCode) ::= <<
-val <p> = codec.decodeConstrainedPosWholeNumber<sSsuffix>(<nMin>.toRawULong, <nMax>.toRawULong) // uper:135
+val <p> = codec.base.decodeConstrainedPosWholeNumber<sSsuffix>(<nMin>.toRawULong, <nMax>.toRawULong) // uper:135
 >>
 
 /*case: A :: = INTEGER */
-IntUnconstrained_encode(p, sErrCode, bCoverageIgnore) ::= "codec.encodeUnconstrainedWholeNumber(<p>)"
+IntUnconstrained_encode(p, sErrCode, bCoverageIgnore) ::= "codec.base.encodeUnconstrainedWholeNumber(<p>)"
 IntUnconstrained_decode(p, sErrCode, bCoverageIgnore) ::= <<
-val <p> = codec.decodeUnconstrainedWholeNumber() // uper:145
+val <p> = codec.base.decodeUnconstrainedWholeNumber() // uper:145
 >>
 
 /*case: A :: = INTEGER(MIN..5) */
-IntUnconstrainedMax_encode(p, nMax, soCheckExp, sErrCode) ::= "codec.encodeUnconstrainedWholeNumber(<p>)"
+IntUnconstrainedMax_encode(p, nMax, soCheckExp, sErrCode) ::= "codec.base.encodeUnconstrainedWholeNumber(<p>)"
 IntUnconstrainedMax_decode(p, nMax, soCheckExp, sErrCode) ::= <<
-if !codec.decodeUnconstrainedWholeNumber() then // TODO meth does not return a boolean value...?
+if !codec.base.decodeUnconstrainedWholeNumber() then // TODO meth does not return a boolean value...?
     <if(soCheckExp)>
     if !<soCheckExp> then return LeftMut(<sErrCode>)
     <else>
@@ -153,16 +153,16 @@ if !codec.decodeUnconstrainedWholeNumber() then // TODO meth does not return a b
 >>
 
 /*case: A:: = INTEGER (-5..MAX) */
-IntSemiConstraint_encode(p, nMin, sErrCode) ::= "codec.encodeSemiConstrainedWholeNumber(<p>, <nMin>)"
+IntSemiConstraint_encode(p, nMin, sErrCode) ::= "codec.base.encodeSemiConstrainedWholeNumber(<p>, <nMin>)"
 IntSemiConstraint_decode(p, nMin, sErrCode) ::= <<
-if !codec.decodeSemiConstrainedWholeNumber(<nMin>) then
+if !codec.base.decodeSemiConstrainedWholeNumber(<nMin>) then
     return LeftMut(<sErrCode>)
 >>
 
 /*case: A:: = INTEGER (5..MAX) */
-IntSemiConstraintPos_encode(p, nMin, sErrCode) ::= "codec.encodeSemiConstrainedPosWholeNumber(<p>, <nMin>)"
+IntSemiConstraintPos_encode(p, nMin, sErrCode) ::= "codec.base.encodeSemiConstrainedPosWholeNumber(<p>, <nMin>)"
 IntSemiConstraintPos_decode(p, nMin, sErrCode) ::= <<
-if !codec.decodeSemiConstrainedPosWholeNumber(<nMin>) then
+if !codec.base.decodeSemiConstrainedPosWholeNumber(<nMin>) then
     return LeftMut(<sErrCode>)
 >>
 
@@ -177,7 +177,7 @@ val <p> = <sConst>
 
 /*case: A:: = INTEGER (5..40,...) */
 IntRootExt_encode(p, nMin, sRootBaseConstraint, sIntBody, sErrCode) ::=<<
-codec.appendBitZero() /* write extension bit*/
+codec.base.appendBitZero() /* write extension bit*/
 <sIntBody>
 >>
 
@@ -186,7 +186,7 @@ IntRootExt_decode(p, nMin, sRootBaseConstraint, sIntBody, sErrCode) ::=<<
     extBit: Ref[Boolean] = Ref(false)
 
     /* read extension bit*/
-    val success = codec.readBit(extBit)
+    val success = codec.base.bitStream.readBit(extBit)
     if success then
         if extBit == false then /* ext bit is zero ==> value is expected with root range*/
             <sIntBody>
@@ -200,11 +200,11 @@ IntRootExt_decode(p, nMin, sRootBaseConstraint, sIntBody, sErrCode) ::=<<
 /*case: A:: = INTEGER (5..40,..., 60..70) */
 IntRootExt2_encode(p, nMin, sRootBaseConstraint, sIntBody, sErrCode) ::=<<
 if <sRootBaseConstraint> then
-    codec.appendBitZero() /* write extension bit, value within root range, so ext bit is zero */
+    codec.base.appendBitZero() /* write extension bit, value within root range, so ext bit is zero */
     <sIntBody>
 else
     /* value is not within root range, so ext bit is one and value is encoded as unconstrained */
-    codec.appendBitOne()
+    codec.base.appendBitOne()
     <IntUnconstrained_encode(p=p, sErrCode=sErrCode)>
 >>
 
@@ -214,16 +214,16 @@ IntRootExt2_decode(p, nMin, sRootBaseConstraint, sIntBody, sErrCode) ::="<IntRoo
 /* INTEGER END*/
 
 Boolean_encode(p, sErrCode) ::= <<
-codec.appendBit(<p>)
+codec.base.bitStream.appendBit(<p>)
 >>
 
 Boolean_decode(p, sErrCode) ::= <<
-val <p> = codec.readBit() // uper:225
+val <p> = codec.base.bitStream.readBit() // uper:225
 >>
 
-Real_encode(p, sSuffix, sErrCode) ::= "codec.encodeReal(<p>)"
+Real_encode(p, sSuffix, sErrCode) ::= "codec.base.encodeReal(<p>)"
 Real_decode(p, sSuffix, sErrCode) ::= <<
-val <p> = codec.decodeReal<sSuffix>().toDouble // uper:234
+val <p> = codec.base.decodeReal<sSuffix>().toDouble // uper:234
 >>
 
 ObjectIdentifier_encode(p, sErrCode) ::= "codec.ObjectIdentifier_encode(<p>);"
@@ -246,7 +246,7 @@ if !codec.<sTimeSubType>_decode() then
 
 Enumerated_item_encode(p, sName, nIndex, nLastItemIndex) ::= <<
 case <sName> =>
-    codec.encodeConstrainedWholeNumber(<nIndex>, 0, <nLastItemIndex>)
+    codec.base.encodeConstrainedWholeNumber(<nIndex>, 0, <nLastItemIndex>)
 >>
 Enumerated_item_decode(p, sName, nIndex, nLastItemIndex) ::= <<
 case <nIndex> => <sName>
@@ -258,7 +258,7 @@ Enumerated_encode(p, td/*:FE_EnumeratedTypeDefinition*/, arrsItem, nMin, nMax, n
 >>
 
 Enumerated_decode(p, td/*:FE_EnumeratedTypeDefinition*/, arrsItem, nMin, nMax, nBits, sErrCode, nLastItemIndex, sFirstItemName) ::= <<
-val <p> = codec.decodeConstrainedWholeNumber(0, <nLastItemIndex>) match // uper:277
+val <p> = codec.base.decodeConstrainedWholeNumber(0, <nLastItemIndex>) match // uper:277
     <arrsItem; separator="\n">
     case _ =>
         return LeftMut(<sErrCode>)
@@ -268,7 +268,7 @@ val <p> = codec.decodeConstrainedWholeNumber(0, <nLastItemIndex>) match // uper:
 
 choice_child_encode(p, sAcc, sChildID, nChildIndex, nIndexSizeInBits, nLastItemIndex, sChildContent, sChildName, sChildTypeDef, sChoiceTypeName, sChildInitExpr, bIsSequence, bIsEnum) ::= <<
 case <sChildID>(<sChildName>) =>
-    codec.encodeConstrainedWholeNumber(<nChildIndex>, 0, <nLastItemIndex>)
+    codec.base.encodeConstrainedWholeNumber(<nChildIndex>, 0, <nLastItemIndex>)
     <sChildContent>
 >>
 
@@ -284,7 +284,7 @@ choice_encode(p, sAcc, arrsChildren, nLastItemIndex, sChoiceIndexName, sErrCode,
 >>
 
 choice_decode(p, sAcc, arrsChildren, nLastItemIndex, sChoiceIndexName, sErrCode, td/*:FE_ChoiceTypeDefinition*/, nIndexSizeInBits) ::= <<
-val <p> = codec.decodeConstrainedWholeNumber(0, <nLastItemIndex>) match // uper:317
+val <p> = codec.base.decodeConstrainedWholeNumber(0, <nLastItemIndex>) match // uper:317
     <arrsChildren: {ch|<ch>}; separator="\n">
     case _ =>
         return LeftMut(<sErrCode>)
@@ -294,14 +294,14 @@ val <p> = codec.decodeConstrainedWholeNumber(0, <nLastItemIndex>) match // uper:
 
 /* SEQUENCE START */
 sequence_presence_bit_encode(p, sAcc, sChName, soExistVar, sErrCode) ::= <<
-codec.appendBit(<p><sAcc><sChName>.isDefined)
+codec.base.bitStream.appendBit(<p><sAcc><sChName>.isDefined)
 >>
 sequence_presence_bit_decode(p, sAcc, sChName, soExistVar, sErrCode) ::= <<
-val <soExistVar> = codec.readBit()
+val <soExistVar> = codec.base.bitStream.readBit()
 >>
 
 sequence_presence_bit_fix_encode(p, sAcc, sChName, soExistVar, sErrCode, sVal) ::= <<
-codec.appendBit(<sVal>)
+codec.base.bitStream.appendBit(<sVal>)
 >>
 
 sequence_presence_bit_fix_decode(p, sAcc, sChName, soExistVar, sErrCode, sVal) ::= <<
@@ -384,14 +384,14 @@ val <p> = <soInitExpr>
 str_VarSize_encode(p, sTasName, i, sInternalItem, nSizeMin, nSizeMax, nSizeInBits, nIntItemMinSize, nIntItemMaxSize, nAlignSize, soInitExpr) ::= <<
 nStringLength = <p>.indexOf(0x00.toRawUByte)
 /*ret = nStringLength >= <nSizeMin> && nStringLength \<= <nSizeMax>;*/
-codec.encodeConstrainedWholeNumber(nStringLength, <nSizeMin>, <nSizeMax>)
+codec.base.encodeConstrainedWholeNumber(nStringLength, <nSizeMin>, <nSizeMax>)
 <loopFixedItem(i=i, sInternalItem=sInternalItem, fixedSize="nStringLength")>
 
 >>
 
 str_VarSize_decode(p, sTasName, i, sInternalItem, nSizeMin, nSizeMax, nSizeInBits, nIntItemMinSize, nIntItemMaxSize, nAlignSize, soInitExpr) ::= <<
 val <p> = <soInitExpr>
-nStringLength = codec.decodeConstrainedWholeNumberInt(<nSizeMin>, <nSizeMax>)
+nStringLength = codec.base.decodeConstrainedWholeNumberInt(<nSizeMin>, <nSizeMax>)
 <p>(nStringLength) = UByte.fromRaw(0)
 
 <i> = 0
@@ -409,56 +409,56 @@ val <p> = <sTasName>(<nFixedSize>, Array.fill(<nFixedSize>)(<sChildInitExpr>))
 >>
 
 seqOf_VarSize_encode(p, sAcc, sTasName, i, sInternalItem, nSizeMin, nSizeMax, nSizeInBits, nIntItemMinSize, nIntItemMaxSize, nAlignSize, sChildInitExpr, sErrCode) ::= <<
-codec.encodeConstrainedWholeNumber(<p><sAcc>nCount, <nSizeMin>, <nSizeMax>)
+codec.base.encodeConstrainedWholeNumber(<p><sAcc>nCount, <nSizeMin>, <nSizeMax>)
 <loopFixedItem(i=i, sInternalItem=sInternalItem, fixedSize=[p, sAcc, "nCount"])>
 >>
 
 seqOf_VarSize_decode(p, sAcc, sTasName, i, sInternalItem, nSizeMin, nSizeMax, nSizeInBits, nIntItemMinSize, nIntItemMaxSize, nAlignSize, sChildInitExpr, sErrCode) ::= <<
-val <p>_nCount = codec.decodeConstrainedWholeNumber(<nSizeMin>, <nSizeMax>).toInt
+val <p>_nCount = codec.base.decodeConstrainedWholeNumber(<nSizeMin>, <nSizeMax>).toInt
 val <p> = <sTasName>(<p>_nCount.toInt, Array.fill(<p>_nCount.toInt)(<sChildInitExpr>))
 <i> = 0
 <loopFixedItem(i=i, sInternalItem=sInternalItem, fixedSize=[p, "_nCount"])>
 >>
 
 octet_FixedSize_encode(sTypeDefName, p, sAcc, nFixedSize) ::= <<
-codec.encodeOctetString_no_length(<p><sAcc>arr, <nFixedSize>.toInt)
+codec.base.encodeOctetString_no_length(<p><sAcc>arr, <nFixedSize>.toInt)
 >>
 
 octet_FixedSize_decode(sTypeDefName, p, sAcc, nFixedSize) ::= <<
-val <p> = <sTypeDefName>(codec.decodeOctetString_no_length(<nFixedSize>))
+val <p> = <sTypeDefName>(codec.base.decodeOctetString_no_length(<nFixedSize>))
 >>
 
 octet_VarSize_encode(sTypeDefName, p, sAcc, nSizeMin, nSizeMax, nSizeInBits, sErrCode) ::= <<
-codec.encodeConstrainedWholeNumber(<p><sAcc>nCount, <nSizeMin>, <nSizeMax>)
-codec.encodeOctetString_no_length(<p><sAcc>arr, <p><sAcc>nCount.toInt)
+codec.base.encodeConstrainedWholeNumber(<p><sAcc>nCount, <nSizeMin>, <nSizeMax>)
+codec.base.encodeOctetString_no_length(<p><sAcc>arr, <p><sAcc>nCount.toInt)
 >>
 
 octet_VarSize_decode(sTypeDefName, p, sAcc, nSizeMin, nSizeMax, nSizeInBits, sErrCode) ::= <<
 // decode length
-val <p>_nCount = codec.decodeConstrainedWholeNumber(<nSizeMin>, <nSizeMax>)
+val <p>_nCount = codec.base.decodeConstrainedWholeNumber(<nSizeMin>, <nSizeMax>)
 // decode payload
-val <p>_arr = codec.decodeOctetString_no_length(<p>_nCount.toInt)
+val <p>_arr = codec.base.decodeOctetString_no_length(<p>_nCount.toInt)
 val <p> = <sTypeDefName>(<p>_nCount, <p>_arr)
 >>
 
 /* BIT STRING*/
 bitString_FixSize_encode(sTypeDefName, p, sAcc, nFixedSize, sErrCode) ::= <<
 assert(<nFixedSize>.toInt >= 0) // overflow may happen during cast
-codec.appendBitsMSBFirst(<p><sAcc>arr, <nFixedSize>.toInt)
+codec.base.bitStream.appendBitsMSBFirst(<p><sAcc>arr, <nFixedSize>.toInt)
 
 >>
 bitString_FixSize_decode(sTypeDefName, p, sAcc, nFixedSize, sErrCode) ::= <<
-val <p> = <sTypeDefName>(codec.readBits(<nFixedSize>.toInt))
+val <p> = <sTypeDefName>(codec.base.bitStream.readBits(<nFixedSize>.toInt))
 >>
 
 bitString_VarSize_encode(sTypeDefName, p, sAcc, nSizeMin, nSizeMax, sErrCode, nSizeInBits) ::= <<
-codec.encodeConstrainedWholeNumber(<p><sAcc>nCount, <nSizeMin>, <nSizeMax>)
+codec.base.encodeConstrainedWholeNumber(<p><sAcc>nCount, <nSizeMin>, <nSizeMax>)
 <bitString_FixSize_encode(sTypeDefName=sTypeDefName, p=p, sAcc=sAcc, nFixedSize=[p, sAcc,"nCount"], sErrCode=sErrCode)>
 >>
 
 bitString_VarSize_decode(sTypeDefName, p, sAcc, nSizeMin, nSizeMax, sErrCode, nSizeInBits) ::= <<
-val <p>_nCount = codec.decodeConstrainedWholeNumber(<nSizeMin>, <nSizeMax>)
-val <p>_arr = codec.readBits(<p>_nCount.toInt)
+val <p>_nCount = codec.base.decodeConstrainedWholeNumber(<nSizeMin>, <nSizeMax>)
+val <p>_arr = codec.base.bitStream.readBits(<p>_nCount.toInt)
 val <p> = <sTypeDefName>(<p>_nCount, <p>_arr)
 >>
 
@@ -470,9 +470,9 @@ FixedSize_Fragmentation_sqf_64K_encode(p, sAcc,sCurOffset, sCurBlockSize, sBlock
 var <sBlockIndex> = 0
 while(<sBlockIndex> \< <nBlocks64K>)
 {
-    codec.encodeConstrainedWholeNumber(0xC4, 0, 0xFF)
+    codec.base.encodeConstrainedWholeNumber(0xC4, 0, 0xFF)
     <if(bIsBitStringType)>
-    codec.appendBitsMSBFirst(&<p><sAcc>arr[<sCurOffset>/8], <sCurBlockSize>.toInt)
+    codec.base.bitStream.appendBitsMSBFirst(&<p><sAcc>arr[<sCurOffset>/8], <sCurBlockSize>.toInt)
 
     <else>
     val <sBLI>=(int)<sCurOffset>
@@ -490,9 +490,9 @@ while(<sBlockIndex> \< <nBlocks64K>)
 FixedSize_Fragmentation_sqf_small_block_encode(p, sAcc,sInternalItem, nBlockSize, sBlockId, sCurOffset, sCurBlockSize, sBLI, sRemainingItemsVar, bIsBitStringType, sErrCodeName) ::=<<
 //encode <nBlockSize> Block
 <sCurBlockSize> = <nBlockSize>;
-codec.encodeConstrainedWholeNumber(<sBlockId>, 0, 0xFF)
+codec.base.encodeConstrainedWholeNumber(<sBlockId>, 0, 0xFF)
 <if(bIsBitStringType)>
-codec.appendBitsMSBFirst(&<p><sAcc>arr[<sCurOffset>/8], <sCurBlockSize>.toInt)
+codec.base.bitStream.appendBitsMSBFirst(&<p><sAcc>arr[<sCurOffset>/8], <sCurBlockSize>.toInt)
 <else>
 for(<sBLI>=(int)<sCurOffset>; <sBLI> \< (int)(<sCurBlockSize> + <sCurOffset>); <sBLI>++)
 {
@@ -506,13 +506,13 @@ for(<sBLI>=(int)<sCurOffset>; <sBLI> \< (int)(<sCurBlockSize> + <sCurOffset>); <
 FixedSize_Fragmentation_sqf_remaining_encode(p, sAcc,sInternalItem, bRemainingItemsWithinByte, nRemainingItemsVar, sCurOffset, sBLI, sRemainingItemsVar, bIsBitStringType, sErrCodeName) ::= <<
 //encode remaining <nRemainingItemsVar> items
 <if(bRemainingItemsWithinByte)>
-codec.encodeConstrainedWholeNumber(<nRemainingItemsVar>, 0, 0xFF)
+codec.base.encodeConstrainedWholeNumber(<nRemainingItemsVar>, 0, 0xFF)
 <else>
-codec.appendBitOne()
-codec.encodeConstrainedWholeNumber(<nRemainingItemsVar>, 0, 0x7FFF)
+codec.base.appendBitOne()
+codec.base.encodeConstrainedWholeNumber(<nRemainingItemsVar>, 0, 0x7FFF)
 <endif>
 <if(bIsBitStringType)>
-codec.appendBitsMSBFirst(<p><sAcc>arr[<sCurOffset>/8], <nRemainingItemsVar>.toInt)
+codec.base.bitStream.appendBitsMSBFirst(<p><sAcc>arr[<sCurOffset>/8], <nRemainingItemsVar>.toInt)
 <else>
 for(<sBLI>=(int)<sCurOffset>; <sBLI> \< (int)(<sCurOffset> + <nRemainingItemsVar>); <sBLI>++)
 {
@@ -535,19 +535,19 @@ while (<sRemainingItemsVar> >= 0x4000 && <sBlockIndex> \< <if(bIsAsciiString)>(a
 {
     if <sRemainingItemsVar> >= 0x10000 then
         <sCurBlockSize> = 0x10000
-        codec.encodeConstrainedWholeNumber(0xC4, 0, 0xFF)
+        codec.base.encodeConstrainedWholeNumber(0xC4, 0, 0xFF)
     else if <sRemainingItemsVar> >= 0xC000 then
         <sCurBlockSize> = 0xC000
-        codec.encodeConstrainedWholeNumber(0xC3, 0, 0xFF)
+        codec.base.encodeConstrainedWholeNumber(0xC3, 0, 0xFF)
     else if <sRemainingItemsVar> >= 0x8000 then
         <sCurBlockSize> = 0x8000
-        codec.encodeConstrainedWholeNumber(0xC2, 0, 0xFF)
+        codec.base.encodeConstrainedWholeNumber(0xC2, 0, 0xFF)
     else
         <sCurBlockSize> = 0x4000
-        codec.encodeConstrainedWholeNumber(0xC1, 0, 0xFF)
+        codec.base.encodeConstrainedWholeNumber(0xC1, 0, 0xFF)
 
     <if(bIsBitStringType)>
-    codec.appendBitsMSBFirst(<p><sAcc>arr[<sCurOffset>/8], <sCurBlockSize>.toInt)
+    codec.base.bitStream.appendBitsMSBFirst(<p><sAcc>arr[<sCurOffset>/8], <sCurBlockSize>.toInt)
     <else>
     <sBLI>=<sCurOffset>.toInt
     while(<sBLI> \< (<sCurBlockSize> + <sCurOffset>).toInt)
@@ -562,13 +562,13 @@ while (<sRemainingItemsVar> >= 0x4000 && <sBlockIndex> \< <if(bIsAsciiString)>(a
 }
 
 if <sRemainingItemsVar> \<= 0x7F then
-    codec.encodeConstrainedWholeNumber(<sRemainingItemsVar>, 0, 0xFF)
+    codec.base.encodeConstrainedWholeNumber(<sRemainingItemsVar>, 0, 0xFF)
 else
-    codec.appendBitOne()
-    codec.encodeConstrainedWholeNumber(<sRemainingItemsVar>, 0, 0x7FFF)
+    codec.base.appendBitOne()
+    codec.base.encodeConstrainedWholeNumber(<sRemainingItemsVar>, 0, 0x7FFF)
 
 <if(bIsBitStringType)>
-codec.appendBitsMSBFirst(<p><sAcc>arr[<sCurOffset>/8], <sRemainingItemsVar>.toInt)
+codec.base.bitStream.appendBitsMSBFirst(<p><sAcc>arr[<sCurOffset>/8], <sRemainingItemsVar>.toInt)
 <else>
 <sBLI> = <sCurOffset>.toInt
 while(<sBLI> \< (<sCurOffset> + <sRemainingItemsVar>).toInt)
@@ -586,12 +586,12 @@ FixedSize_Fragmentation_sqf_64K_decode(p, sAcc,sCurOffset, sCurBlockSize, sBlock
 <sCurOffset> = 0;
 *pErrCode = <sErrCodeName>;
 for(<sBlockIndex> = 0; ret && <sBlockIndex> \< <nBlocks64K>; <sBlockIndex>++) {
-    ret = codec.decodeConstrainedWholeNumber(<sRemainingItemsVar>, 0, 0xFF)
+    ret = codec.base.decodeConstrainedWholeNumber(<sRemainingItemsVar>, 0, 0xFF)
     val check = (ret == 0) && (<sRemainingItemsVar> == 0xC4);
     ret = if (check) then RightMut(0) else LeftMut(<sErrCodeName>)
     if ret == 0 then
         <if(bIsBitStringType)>
-        ret = codec.readBits(&<p><sAcc>arr[<sCurOffset>/8], <sCurBlockSize>).toInt
+        ret = codec.base.bitStream.readBits(&<p><sAcc>arr[<sCurOffset>/8], <sCurBlockSize>).toInt
         ret = if (ret == 0) 0 else <sErrCodeName>;
 
         <else>
@@ -612,12 +612,12 @@ for(<sBlockIndex> = 0; ret && <sBlockIndex> \< <nBlocks64K>; <sBlockIndex>++) {
 FixedSize_Fragmentation_sqf_small_block_decode(p, sAcc,sInternalItem, nBlockSize, sBlockId, sCurOffset, sCurBlockSize, sBLI, sRemainingItemsVar, bIsBitStringType, sErrCodeName) ::=<<
 //decode a single Block with <nBlockSize> items
 <sCurBlockSize> = <nBlockSize>;
-ret = codec.decodeConstrainedWholeNumber(<sRemainingItemsVar>, 0, 0xFF)
+ret = codec.base.decodeConstrainedWholeNumber(<sRemainingItemsVar>, 0, 0xFF)
 val check = (ret == 0) && (<sRemainingItemsVar> == <sBlockId>);
 ret = if (check) then RightMut(0) else LeftMut(<sErrCodeName>)
 if ret.isRight then
 <if(bIsBitStringType)>
-    ret = codec.readBits(&<p><sAcc>arr[<sCurOffset>/8], <sCurBlockSize>.toInt); // TODO call wrong
+    ret = codec.base.bitStream.readBits(&<p><sAcc>arr[<sCurOffset>/8], <sCurBlockSize>.toInt); // TODO call wrong
     ret = if (ret == 0) then RightMut(0) else LeftMut(<sErrCodeName>)
 
 <else>
@@ -634,17 +634,17 @@ if ret.isRight then
 FixedSize_Fragmentation_sqf_remaining_decode(p, sAcc,sInternalItem, bRemainingItemsWithinByte, nRemainingItemsVar, sCurOffset, sBLI, sRemainingItemsVar, bIsBitStringType, sErrCodeName) ::= <<
 //decode remaining <nRemainingItemsVar> items
 <if(bRemainingItemsWithinByte)>
-ret = codec.decodeConstrainedWholeNumber(<sRemainingItemsVar>, 0, 0xFF)
+ret = codec.base.decodeConstrainedWholeNumber(<sRemainingItemsVar>, 0, 0xFF)
 ret  = ret && (<sRemainingItemsVar> == <nRemainingItemsVar>);
 
 <else>
-ret = codec.decodeConstrainedWholeNumber(<sRemainingItemsVar>, 0, 0xFFFF)
+ret = codec.base.decodeConstrainedWholeNumber(<sRemainingItemsVar>, 0, 0xFFFF)
 ret = ret && ((0x8000 & <sRemainingItemsVar>) > 0) && ( (0x7FFF & <sRemainingItemsVar>) == <nRemainingItemsVar>);
 
 <endif>
 if ret == 0 then
     <if(bIsBitStringType)>
-    ret = codec.readBits(&<p><sAcc>arr[<sCurOffset>/8], <nRemainingItemsVar>.toInt); // TODO call wrong
+    ret = codec.base.bitStream.readBits(&<p><sAcc>arr[<sCurOffset>/8], <nRemainingItemsVar>.toInt); // TODO call wrong
     ret = if (ret.isRight) then RightMut(0) else LeftMut(<sErrCodeName>)
 
     <else>
@@ -674,7 +674,7 @@ Fragmentation_sqf_decode(p, sAcc, sInternalItem, nIntItemMaxSize, nSizeMin, nSiz
 <sLengthTmp> = 0
 <endif>
 
-<sRemainingItemsVar> = codec.decodeConstrainedWholeNumber(0, 0xFF).toInt // uper:733
+<sRemainingItemsVar> = codec.base.decodeConstrainedWholeNumber(0, 0xFF).toInt // uper:733
 
 while((<sRemainingItemsVar> & 0xC0) == 0xC0) {
     if <sRemainingItemsVar> == 0xC4 then
@@ -692,7 +692,7 @@ while((<sRemainingItemsVar> & 0xC0) == 0xC0) {
         return LeftMut(<sErrCodeName>)
 
     <if(bIsBitStringType)>
-    if !codec.readBits(&<p><sAcc>arr[<sCurOffset>/8], <sCurBlockSize>) then
+    if !codec.base.bitStream.readBits(&<p><sAcc>arr[<sCurOffset>/8], <sCurBlockSize>) then
        return <sErrCodeName>
     <else>
     <sBLI> = <sCurOffset>
@@ -707,13 +707,13 @@ while((<sRemainingItemsVar> & 0xC0) == 0xC0) {
     <sLengthTmp> += <sCurBlockSize>
     <endif>
     <sCurOffset> += <sCurBlockSize>
-    <sRemainingItemsVar> = codec.decodeConstrainedWholeNumber(0, 0xFF).toInt // uper:770
+    <sRemainingItemsVar> = codec.base.decodeConstrainedWholeNumber(0, 0xFF).toInt // uper:770
 }
 
 if ((<sRemainingItemsVar> & 0x80) > 0) then
     var len2 = 0;
     <sRemainingItemsVar> \<\<= 8
-    len2 = codec.decodeConstrainedWholeNumber(0, 0xFF).toInt // uper:780
+    len2 = codec.base.decodeConstrainedWholeNumber(0, 0xFF).toInt // uper:780
 
     <sRemainingItemsVar> |= len2;
     <sRemainingItemsVar> &= 0x7FFF;
@@ -722,7 +722,7 @@ if (<sCurOffset> + <sRemainingItemsVar> \<= <nSizeMax>) then
     return LeftMut(<sErrCodeName>)
 
 <if(bIsBitStringType)>
-if(!codec.readBits(&<p><sAcc>arr[<sCurOffset>/8], <sRemainingItemsVar>.toInt)) // TODO remove address of operator
+if(!codec.base.bitStream.readBits(&<p><sAcc>arr[<sCurOffset>/8], <sRemainingItemsVar>.toInt)) // TODO remove address of operator
     return <sErrCodeName>
 
 <else>

--- a/asn1scala/src/main/scala/asn1scala/asn1jvm_Codec.scala
+++ b/asn1scala/src/main/scala/asn1scala/asn1jvm_Codec.scala
@@ -24,7 +24,7 @@ val CHAR_ZERO: Byte = 48
 val CHAR_NINE: Byte = 57
 val CHAR_0000: Byte = 0
 
-@extern 
+@extern
 def assume(b: Boolean): Unit = {}.ensuring(_ => b)
 
 /***********************************************************************************************/
@@ -366,8 +366,8 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       val range = stainless.math.wrapping(max - min)
       val nBits = GetBitCountUnsigned(range.toRawULong)
       w1.bitStream.buf.length == w2.bitStream.buf.length
-      && BitStream.bitIndex(w2.bitStream.buf.length, w2.bitStream.currentByte, w2.bitStream.currentBit) == BitStream.bitIndex(w1.bitStream.buf.length, w1.bitStream.currentByte, w1.bitStream.currentBit) + nBits && 
-      w1.isPrefixOf(w2) 
+      && BitStream.bitIndex(w2.bitStream.buf.length, w2.bitStream.currentByte, w2.bitStream.currentBit) == BitStream.bitIndex(w1.bitStream.buf.length, w1.bitStream.currentByte, w1.bitStream.currentBit) + nBits &&
+      w1.isPrefixOf(w2)
       && {
          val (r1, r2) = reader(w1, w2)
          validateOffsetBitsContentIrrelevancyLemma(w1.bitStream, w2.bitStream.buf, nBits)
@@ -418,7 +418,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
             min
          else
             res
-   } ensuring( res => 
+   } ensuring( res =>
       res >= min && res <= max &&
       BitStream.invariant(bitStream.currentBit, bitStream.currentByte, bitStream.buf.length)
    )
@@ -521,7 +521,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       // assert(nBytes.toRaw > 0)
       // assert(BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,nBytes.toRaw)) // SAM Cannot be proven now.
       // decode number
-      // SAM: without an invariant here, it is impossible to prove that nBytes <= 8, so we need 
+      // SAM: without an invariant here, it is impossible to prove that nBytes <= 8, so we need
       // an guard here.
       val nBytesRaw = nBytes.toRaw
       val nBits = nBytesRaw * NO_OF_BITS_IN_BYTE
@@ -580,7 +580,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       // check bitstream precondition
       // SAM assert(BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,nBytes.toRaw))
       // decode number
-      val nBytesRaw = nBytes.toRaw 
+      val nBytesRaw = nBytes.toRaw
       val nBits = nBytesRaw * NO_OF_BITS_IN_BYTE
       // SAM GUARD
       val v = if(!(nBits >= 0 && nBits <= 64) || !BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, nBits)){
@@ -734,7 +734,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          nExpLen >= 1 && nExpLen <= 2 && nManLen <= 7 &&
          (if (vVal == DoublePosZeroBitString ) then
             BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,8 )
-         else if (vVal == DoubleNegZeroBitString || (vVal & ExpoBitMask) == ExpoBitMask) then 
+         else if (vVal == DoubleNegZeroBitString || (vVal & ExpoBitMask) == ExpoBitMask) then
             BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,16)
          else
             BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,16 + nManLen  + nExpLen )
@@ -748,7 +748,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       if v == DoublePosZeroBitString then
          check( BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,8))
          encodeConstrainedWholeNumber(0, 0, 0xFF)
-         
+
 
       // 8.5.3 Minus Zero
       else if v == DoubleNegZeroBitString then
@@ -756,7 +756,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          encodeConstrainedWholeNumber(1, 0, 0xFF)
          check( BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,8))
          encodeConstrainedWholeNumber(0x43, 0, 0xFF)
-         
+
 
       // 8.5.9 SpecialRealValues
       else if (v & ExpoBitMask) == ExpoBitMask then
@@ -808,24 +808,24 @@ case class Codec private [asn1scala](bitStream: BitStream) {
             header |= 0x01
          else if nExpLen == 3 then // this will never happen with this implementation
             header |= 0x02
-         
+
          /* encode length */
          BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,16 + nManLen  + nExpLen )
 
          encodeConstrainedWholeNumber(1 + nExpLen + nManLen, 0, 0xFF)
-         
+
          check(BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,8 + nManLen * NO_OF_BITS_IN_BYTE + nExpLen * NO_OF_BITS_IN_BYTE))
          // /* encode header */
          BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,8 + nManLen  + nExpLen )
 
          encodeConstrainedWholeNumber(header & 0xFF, 0, 0xFF)
-         
+
           BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,nManLen  + nExpLen )
 
          // TODO this might be more complicated, because by removing the require in the bistream class, I'll in fact break the safety there
          /* encode exponent */
          if exponent.toRaw >= 0 then
-            // fill with zeros to have a whole byte   
+            // fill with zeros to have a whole byte
             assert(BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,nManLen * NO_OF_BITS_IN_BYTE + nExpLen * NO_OF_BITS_IN_BYTE))
             appendNZeroBits(nExpLen * NO_OF_BITS_IN_BYTE - GetBitCountUnsigned(exponent.toULong))
             assert(BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,nManLen * NO_OF_BITS_IN_BYTE + GetBitCountUnsigned(exponent.toULong)))
@@ -838,7 +838,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
             assert(BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, GetBitCountUnsigned(compactExp.toLong.toRawULong)))
             encodeUnsignedInteger(compactExp.toLong.toRawULong)
             check(BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,nManLen * NO_OF_BITS_IN_BYTE ))
-            
+
          /* encode mantissa */
          assert(BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, nManLen * NO_OF_BITS_IN_BYTE ))
          @ghost val bitIndexBeforeAppendingZeros = BitStream.bitIndex(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit)
@@ -868,7 +868,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       require(BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,1))
       // staticRequire({
       //    val length = readBytePure()._2.toRaw
-      //    length >= 0 
+      //    length >= 0
       //    && length != 1 // Otherwise there's only the space for the header SAM
       //    && length <= DoubleMaxLengthOfSentBytes
       //    && BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,1 + length.toInt)
@@ -877,7 +877,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
 
       // get length
       val length = readByte().toRaw
-      if(length >= 0 
+      if(length >= 0
             && length != 1 // Otherwise there's only the space for the header SAM
             && length <= DoubleMaxLengthOfSentBytes
             && BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,1 + length.toInt)) then
@@ -928,7 +928,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
     * Decode real number from bitstream, special cases are decoded by caller
     * The exponent length and other details given in the header have be be
     * decoded before calling this function
-    * 
+    *
     * If the buffer is invalid (too short or malformed), has an undefined behaviour, but does not crash.
     *
     * @param lengthVal already decoded exponent length
@@ -983,9 +983,9 @@ case class Codec private [asn1scala](bitStream: BitStream) {
 
       // SAM guard if for the exponent read from the bitstream
       // assert(exponent < (Int.MaxValue / 4) && exponent >= -1)
-      if(exponent >= (Int.MaxValue / 4) || exponent <= -1) then 
+      if(exponent >= (Int.MaxValue / 4) || exponent <= -1) then
          0L
-      else 
+      else
          // decode mantissa parts
          val length = lengthVal - expLen
          var N: Long = 0
@@ -997,14 +997,14 @@ case class Codec private [asn1scala](bitStream: BitStream) {
 
             j += 1
          ).invariant(
-            j >= 0 && 
-            j <= length && 
+            j >= 0 &&
+            j <= length &&
             BitStream.invariant(bitStream.currentBit, bitStream.currentByte, bitStream.buf.length) &&
             BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, length - j))
 
          // assert(N < (Long.MaxValue / 8) && N >= 0) // TODO Check the doc to see if N has a max value, otherwise there is a bug here
          // SAM guard if for the mantissa read from the bitstream
-         if(N >= (Long.MaxValue / 8) || N < 0) then 
+         if(N >= (Long.MaxValue / 8) || N < 0) then
             0L
          else
             val x1: ULong = (N * factor).toRawULong
@@ -1047,7 +1047,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       val resInner = encodeOctetString_fragmentation_innerWhile(arr, nCount, 0, nRemainingItemsVar1, nCurOffset1, BitStream.bitIndex(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit ))
       assert(BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, resInner._1 + 2))
       ghostExpr(check(BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, resInner._1 + 2)))
-      
+
       nRemainingItemsVar1 = resInner._1
       nCurOffset1 = resInner._2
 
@@ -1085,7 +1085,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          assert(BitStream.bitIndex(bufLength, bitStream.currentByte, bitStream.currentBit) == bitIndexAfterInnerWhile + 1)
          ghostExpr(check(BitStream.validate_offset_bits(bufLength, bitStream.currentByte, bitStream.currentBit, 15))) // == GetLengthForEncodingUnsigned(0x7FFF)
 
-         encodeConstrainedWholeNumber(nRemainingItemsVar1.toLong, 0, 0x7FFF) 
+         encodeConstrainedWholeNumber(nRemainingItemsVar1.toLong, 0, 0x7FFF)
          assert(BitStream.bitIndex(bufLength, bitStream.currentByte, bitStream.currentBit) == bitIndexAfterInnerWhile + 16)
          assert(BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, nRemainingItemsVar1 ))
          ghostExpr(check(BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, nRemainingItemsVar1 )))
@@ -1136,7 +1136,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       @ghost val bufferLength = bitStream.buf.length
 
       if (nRemainingItemsVar1 >= 0x4000) then
-         val nCurBlockSize1 = 
+         val nCurBlockSize1 =
             if nRemainingItemsVar1 >= 0x10000 then
                0x10000
             else if nRemainingItemsVar1 >= 0xC000 then
@@ -1145,31 +1145,31 @@ case class Codec private [asn1scala](bitStream: BitStream) {
                0x8000
             else
                0x4000
-                     
+
          // Write to the buffer the block header and return the number of blocks of 0x4000 it would represent
          val blockSize: Long = nCurBlockSize1 match {
-            case 0x10000 => 
+            case 0x10000 =>
                0xC4
-            case 0xC000 => 
+            case 0xC000 =>
                0xC3
-            case 0x8000 => 
+            case 0x8000 =>
                0xC2
-            case 0x4000 => 
+            case 0x4000 =>
                0xC1
          }
 
          val nNewBlocksOf0x4000 = blockSize match {
-            case 0xC4 => 
+            case 0xC4 =>
                4
-            case 0xC3 => 
+            case 0xC3 =>
                3
-            case 0xC2 => 
+            case 0xC2 =>
                2
-            case 0xC1 => 
+            case 0xC1 =>
                1
          }
-                                 
-         @ghost val bitIndexBeforeHeader = BitStream.bitIndex(bufferLength, bitStream.currentByte, bitStream.currentBit )   
+
+         @ghost val bitIndexBeforeHeader = BitStream.bitIndex(bufferLength, bitStream.currentByte, bitStream.currentBit )
          assert(GetBitCountUnsigned(0xFF.toRawULong) == 8)
 
          ghostExpr(check(bitIndexBeforeHeader == bitIndex))
@@ -1177,7 +1177,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          encodeConstrainedWholeNumber(blockSize, 0, 0xFF)
 
          assert(bitStream.buf.length == bufferLength)
-         
+
 
          @ghost val bitIndexAfterHeader = BitStream.bitIndex(bufferLength, bitStream.currentByte, bitStream.currentBit )
          @ghost val currentByteAfterHeader = bitStream.currentByte
@@ -1186,7 +1186,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          assert(bitIndexBeforeHeader + NO_OF_BITS_IN_BYTE == bitIndexAfterHeader)
          assert( bitIndexAfterHeader <= bitIndexBeforeHeader + 4 * NO_OF_BITS_IN_BYTE)
          ghostExpr(check(( bitIndexAfterHeader <= bitIndexBeforeHeader + 4 * NO_OF_BITS_IN_BYTE)))
-         
+
          val validatedOffset1: Int = nRemainingItemsVar1 + (nRemainingItemsVar1 / 0x4000) - 1 + 2
 
          assert(BitStream.validate_offset_bytes(bufferLength, bitStream.currentByte, bitStream.currentBit, validatedOffset1))
@@ -1198,7 +1198,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          assert(nCurOffset1 + nCurBlockSize1 <= nCount)
          assert(nCurOffset1 + nCurBlockSize1 <= arr.length)
          assert(nCurOffset1 + nCurBlockSize1 >= 0)
-         
+
          encodeOctetString_fragmentation_innerMostWhile(arr, nCurOffset1, nCurOffset1 + nCurBlockSize1, BitStream.bitIndex(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit ))
 
          assert(bitStream.buf.length == bufferLength)
@@ -1211,7 +1211,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          ghostExpr(check((bitIndexAfterAppending == bitIndexAfterHeader + nCurBlockSize1 * 8)))
 
          assert(bitIndexAfterAppending - bitIndexAfterHeader == nCurBlockSize1 * 8)
-         
+
          val newRemaingItems = nRemainingItemsVar1 - nCurBlockSize1
          @ghost val newWrittenBlocks = currentlyWrittenBlocksOf0x4000 + nNewBlocksOf0x4000
          val newOffset = nCurOffset1 + nCurBlockSize1
@@ -1236,12 +1236,12 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          assert(bitIndexAfterAppending - bitIndexAfterHeader <= 8*validatedOffset1 - 8*validatedOffset2)
 
          assert(BitStream.validate_offset_bytes(bufferLength, currentByteAfterHeader, currentBitAfterHeader, validatedOffset1)) // should pass
-         
+
          assert(BitStream.validate_offset_bits(bufferLength, currentByteAfterHeader, currentBitAfterHeader, 8*validatedOffset1))
 
 
          ghostExpr(lemmaAdvanceBitIndexLessMaintainOffset(bufferLength, currentByteAfterHeader, currentBitAfterHeader, bitIndexAfterHeader, currentByteAfterAppending, currentBitAfterAppending, bitIndexAfterAppending, 8*validatedOffset1, 8*validatedOffset2))
-         
+
          assert((BitStream.validate_offset_bits(bufferLength, bitStream.currentByte, bitStream.currentBit, 8*validatedOffset2)))
          ghostExpr(lemmaValidateOffsetBitsBytesEquiv(bufferLength, bitStream.currentByte, bitStream.currentBit, 8*validatedOffset2, validatedOffset2))
          assert((BitStream.validate_offset_bytes(bufferLength, bitStream.currentByte, bitStream.currentBit, validatedOffset2)))
@@ -1253,7 +1253,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          ghostExpr(check(BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, res._1 + 2)))
          ghostExpr(check(BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, resNRemaining + 2)))
          @ghost val bitIndexAfterRecursive = BitStream.bitIndex(bufferLength, bitStream.currentByte, bitStream.currentBit )
-         
+
          assert(resNRemaining + resOffset == nCount)
          assert(resNRemaining <= 0x4000)
          assert(bitIndexAfterRecursive <= bitIndexAfterAppending + (newRemaingItems / 0x4000) * 8 + newRemaingItems * 8 - resNRemaining*8)
@@ -1285,7 +1285,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          ghostExpr(check(nCurOffset1 >= 0 ))
          ghostExpr(check(nRemainingItemsVar1 <= 0x4000 ))
          (nRemainingItemsVar1, nCurOffset1)
-   } ensuring(res => 
+   } ensuring(res =>
          BitStream.bitIndex(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit ) <= bitIndex + (nRemainingItemsVar1 / 0x4000) * 8 + nRemainingItemsVar1 * 8 - res._1 * 8 &&
          BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, res._1 + 2) &&
          BitStream.invariant(bitStream.currentBit, bitStream.currentByte, bitStream.buf.length) &&
@@ -1334,7 +1334,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          assert(bitIndexAfterRecursive == bitIndexBeforeRecursive  + (to - from - 1) * NO_OF_BITS_IN_BYTE)
          assert(NO_OF_BITS_IN_BYTE + (to - from - 1) * NO_OF_BITS_IN_BYTE == (to - from) * NO_OF_BITS_IN_BYTE)
          assert(bitIndexAfterRecursive == bitIndexBeforeAppending + NO_OF_BITS_IN_BYTE + (to - from - 1) * NO_OF_BITS_IN_BYTE)
-   } ensuring(_ => 
+   } ensuring(_ =>
       val oldBitStream = old(this).bitStream
       BitStream.bitIndex(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit ) == bitIndex + (to - from) * NO_OF_BITS_IN_BYTE &&
       oldBitStream.buf.length == bitStream.buf.length
@@ -1354,7 +1354,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
    def lemmaGetBitCountUnsigned7FFFEquals15(): Unit = {
 
    } ensuring(_ => GetBitCountUnsigned(stainless.math.wrapping(0x7FFF).toRawULong) == 15)
-   
+
    @ghost
    @opaque
    @inlineOnce
@@ -1365,7 +1365,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       require(offsetBytes < Int.MaxValue / 8)
       require(offsetBits == offsetBytes * 8)
       require(BitStream.validate_offset_bits(bufLength, currentByte, currentBit, offsetBits))
-      
+
    } ensuring(_ => BitStream.validate_offset_bytes(bufLength, currentByte, currentBit, offsetBytes))
    /**
      * Takes more than 100sec to verify, that's why it is extracted to a lemma, even though it does not need a specific proof
@@ -1384,7 +1384,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
    @opaque
    @inlineOnce
    def lemmaAdvanceBitIndexLessMaintainOffset(
-      bufLength: Int, 
+      bufLength: Int,
       currentByte1: Int, currentBit1: Int, bitIndex1: Long,
       currentByte2: Int, currentBit2: Int, bitIndex2: Long,
       offset1Bits: Int,
@@ -1453,7 +1453,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          nRemainingItemsVar1 &= 0x7FFF // clear the control bit
 
       // SAM Guard if
-      if(nRemainingItemsVar1 < 0 || nRemainingItemsVar1 > asn1SizeMax || nCurOffset1 > asn1SizeMax - nRemainingItemsVar1 ) then 
+      if(nRemainingItemsVar1 < 0 || nRemainingItemsVar1 > asn1SizeMax || nCurOffset1 > asn1SizeMax - nRemainingItemsVar1 ) then
          return arr
 
       assert(nCurOffset1 + nRemainingItemsVar1 <= asn1SizeMax) // TODO check with C implementation and standard
@@ -1478,9 +1478,9 @@ case class Codec private [asn1scala](bitStream: BitStream) {
 
 
       // // resize output array and copy data
-      assert((nLengthTmp1 >= 0) && (nLengthTmp1 <= asn1SizeMax)) 
+      assert((nLengthTmp1 >= 0) && (nLengthTmp1 <= asn1SizeMax))
       // assert((nLengthTmp1 >= 1) && (nLengthTmp1 <= asn1SizeMax)) // TODO check with C implementation and standard
-      // SAM according to the C implementation, if the nLengthTmp1 == 0, it should fail, so 
+      // SAM according to the C implementation, if the nLengthTmp1 == 0, it should fail, so
       if(nLengthTmp1 == 0) then
          return Array.empty
 
@@ -1565,16 +1565,16 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          // unsupported format
          -1L
          // assert(false, "unsupported format")
-      
+
       if nCurBlockSize1 == -1L then
          return (-1, -1L)
-      
+
       if nCurBlockSize1 == 1L then
          return (nRemainingItemsVar1, nCurOffset1)
 
       if(nCurOffset1 > (asn1SizeMax.toLong - nCurBlockSize1)) then
          return (-1, -1L)
-            
+
       assert(arr.length == asn1SizeMax.toInt)
       decodeOctetString_fragmentation_innerMostWhile(arr, asn1SizeMax, nCurOffset1.toInt, nCurOffset1.toInt + nCurBlockSize1.toInt)
 
@@ -1591,16 +1591,16 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       assert(arr.length == asn1SizeMax.toInt)
       decodeOctetString_fragmentation_innerWhile(arr, asn1SizeMax, newNCurOffset1)
 
-   } ensuring(res => 
+   } ensuring(res =>
       (res._2 >= 0 && res._2 <= asn1SizeMax || res == (-1L, -1L)) &&
       BitStream.invariant(bitStream.currentBit, bitStream.currentByte, bitStream.buf.length) &&
       old(this).bitStream.buf.length == bitStream.buf.length &&
       arr.length == asn1SizeMax.toInt &&
       old(arr).length == arr.length
-      ) 
+      )
 
    /**
-     * Read bytes from bitstream, and write them in the array, starting at from and to to index. 
+     * Read bytes from bitstream, and write them in the array, starting at from and to to index.
      * If the bitstream is invalid, abort.
      *
      * @param arr
@@ -1637,9 +1637,9 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       arr(from) = nextByte
       decodeOctetString_fragmentation_innerMostWhile(arr, asn1SizeMax, from + 1, to)
       ()
-      
-   } ensuring(_ => 
-      old(this).buf.length == bitStream.buf.length && 
+
+   } ensuring(_ =>
+      old(this).buf.length == bitStream.buf.length &&
       arr.length == asn1SizeMax.toInt &&
       BitStream.invariant(bitStream.currentBit, bitStream.currentByte, bitStream.buf.length) &&
       old(this).bitStream.buf.length == bitStream.buf.length &&
@@ -1692,7 +1692,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       assert(nCount >= asn1SizeMin && nCount <= asn1SizeMax) // TODO check with C implementation and standard
 
       assert(BitStream.invariant(bitStream.currentBit, bitStream.currentByte, bitStream.buf.length))
-      if(!BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,nCount)) then 
+      if(!BitStream.validate_offset_bytes(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit,nCount)) then
          return Array.empty
       decodeOctetString_no_length(nCount)
    }
@@ -1723,7 +1723,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          var nRemainingItemsVar1: Long = nCount.toLong
          var nCurBlockSize1: Long = 0
          var nCurOffset1: Long = 0
-        
+
          val res = encodeBitString_while(arr, nCount, asn1SizeMin, asn1SizeMax, nRemainingItemsVar1, nCurOffset1, BitStream.bitIndex(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit))
          nRemainingItemsVar1 = res._1
          nCurOffset1 = res._2
@@ -1763,9 +1763,9 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       staticRequire(BitStream.invariant(bitStream.currentBit, bitStream.currentByte, bitStream.buf.length))
       require(BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, nRemainingItemsVar1 + 8*(nRemainingItemsVar1 / 0x4000) + 16))
 
-      
+
       decreases(nCount - nCurOffset1)
-      
+
       assert(nCount == nRemainingItemsVar1 + nCurOffset1)
       if(nRemainingItemsVar1 < 0x4000) then
          (nRemainingItemsVar1, nCurOffset1)
@@ -1780,7 +1780,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
             0x4000
 
          @ghost val bitIndexBeforeHeader = BitStream.bitIndex(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit)
-         @ghost val currentByteBeforeHeader = bitStream.currentByte 
+         @ghost val currentByteBeforeHeader = bitStream.currentByte
          @ghost val currentBitBeforeHeader = bitStream.currentBit
          @ghost val bufferLength = bitStream.buf.length
 
@@ -1822,9 +1822,9 @@ case class Codec private [asn1scala](bitStream: BitStream) {
 
          assert(BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, nRemainingItemsVar1 + 8*(nRemainingItemsVar1 / 0x4000) + 16 - nCurBlockSize1 - 8)) // REALLY SLOW : > 160sec
          assert(BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, newRemaingItems + 8*(newRemaingItems / 0x4000) + 16))
-         
+
          encodeBitString_while(arr, nCount, asn1SizeMin, asn1SizeMax, newRemaingItems, newOffset, newBitIndex)
-   } ensuring (res => 
+   } ensuring (res =>
       BitStream.invariant(bitStream.currentBit, bitStream.currentByte, bitStream.buf.length) &&
       // BitStream.bitIndex(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit ) <= bitIndex + (nRemainingItemsVar1 / 0x4000) * 8 + nRemainingItemsVar1 - res._1 &&
       BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, res._1 + 16) &&
@@ -1846,7 +1846,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          if asn1SizeMin != asn1SizeMax then
             if !BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, GetBitCountUnsigned(stainless.math.wrapping(asn1SizeMax - asn1SizeMin).toRawULong)) then
                return Array.empty
-            
+
             assert(BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, GetBitCountUnsigned(stainless.math.wrapping(asn1SizeMax - asn1SizeMin).toRawULong)))
             nCount = decodeConstrainedWholeNumber(asn1SizeMin, asn1SizeMax)
          else
@@ -1881,12 +1881,12 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          nRemainingItemsVar1 &= 0x7FFF
 
       assert(nRemainingItemsVar1 >= 0 && nRemainingItemsVar1 <= 0x7FFF)
-      
+
       if nCurOffset1 + nRemainingItemsVar1 > asn1SizeMax then
          return Array.empty
 
       assert(nCurOffset1 + nRemainingItemsVar1 <= asn1SizeMax)
-      
+
       assert(BitStream.invariant(bitStream.currentBit, bitStream.currentByte, bitStream.buf.length))
       if !BitStream.validate_offset_bits(bitStream.buf.length, bitStream.currentByte, bitStream.currentBit, nRemainingItemsVar1.toInt) then
          return Array.empty
@@ -1898,7 +1898,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       assert(nRemainingItemsVar1.toInt <= asn1SizeMax.toInt)
       assert(readBitsArray.length == ((nRemainingItemsVar1 + NO_OF_BITS_IN_BYTE - 1) / NO_OF_BITS_IN_BYTE).toInt)
       arrayCopyOffsetLen(readBitsArray, arr, 0, (nCurOffset1 / 8).toInt, readBitsArray.length)
-      
+
       nLengthTmp1 += nRemainingItemsVar1
 
       // Same as in decodeOctetString, we can only prove >= 0, not >= 1; at least not without assuming things about the buffer
@@ -1953,7 +1953,7 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          return (-1L, -1L)
 
       val nRemainingItemsVar1: Long = decodeConstrainedWholeNumber(0, 0xFF)
-      
+
       if (nRemainingItemsVar1 & 0xC0) != 0xC0 then
          return (nRemainingItemsVar1, nCurOffset1)
 
@@ -1981,11 +1981,11 @@ case class Codec private [asn1scala](bitStream: BitStream) {
       if(arr.length < readBitsArrayLength ) then
          // the output array is too small, probably the bitstream is malformed (i.e., to many block headers or too big block sizes)
          return (-1L, -1L)
-      
+
       if((nCurOffset1 / 8).toInt > arr.length - readBitsArrayLength) then
          // the output array is also too small, probably the bitstream is malformed (i.e., to many block headers or too big block sizes)
          return (-1L, -1L)
-      
+
       assert(0 <= readBitsArrayLength && readBitsArrayLength <= arr.length)
       assert(0 <= (nCurOffset1 / 8).toInt && (nCurOffset1 / 8).toInt <= arr.length - readBitsArrayLength)
       arrayCopyOffsetLen(readBits(nCurBlockSize1.toInt), arr, 0, (nCurOffset1 / 8).toInt, readBitsArrayLength)
@@ -1999,14 +1999,14 @@ case class Codec private [asn1scala](bitStream: BitStream) {
          return (-1L, -1L)
       decodeBitString_while(asn1SizeMin, asn1SizeMax, newNCurOffset1, arr)
 
-   } ensuring (res => 
-      res == (-1L, -1L) 
-      || 
+   } ensuring (res =>
+      res == (-1L, -1L)
+      ||
       res._1 >= 0 && res._1 <= 0xFF &&
-      res._2 >= 0 && res._2 <= asn1SizeMax && 
+      res._2 >= 0 && res._2 <= asn1SizeMax &&
       BitStream.invariant(bitStream.currentBit, bitStream.currentByte, bitStream.buf.length) &&
       old(this).bitStream.buf.length == bitStream.buf.length &&
       arr.length == asn1SizeMax.toInt &&
       old(arr).length == arr.length
-      )  
+      )
 }

--- a/asn1scala/src/main/scala/asn1scala/asn1jvm_Codec_UPER.scala
+++ b/asn1scala/src/main/scala/asn1scala/asn1jvm_Codec_UPER.scala
@@ -18,7 +18,7 @@ def initUPERCodec(count: Int): UPER = {
    if count <= 0 then
       UPER(Codec(BitStream(Array.fill(0)(0))))
    else
-      UPER(Codec(BitStream(Array.fill(count)(0))))  
+      UPER(Codec(BitStream(Array.fill(count)(0))))
 }
 object UPER {
    @ghost @pure


### PR DESCRIPTION
(Note: I've ran the tests and some fail, but this is due to bugs on my side, on the `runtime-safety` branch that I'll fix separately).